### PR TITLE
Refactor security docs

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -86,4 +86,4 @@ app.get('/docs/:dir/:file', handlePage)
 
 
 const port = process.env.POST | 3000
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.listen(port, () => console.log(`Documentation served from http://localhost:${port}/docs`))

--- a/docs/manual/security/index.md
+++ b/docs/manual/security/index.md
@@ -4,7 +4,7 @@ Space Cloud leverages multiple security systems with the philosophy that applica
 
 Every module in Space Cloud supports JWT-based authentication. Access to any database not specified in the configuration file is denied by default. Whenever possible, use JWT-based authentication in production. You can check out the [official website](https://jwt.io) of the JWT project to learn more about it.
 
-## How JWT are tokens used
+## How JWT is used
 
 `space-cloud` looks for the JWT token in the `Authorization` header in each HTTP request made to it.
 

--- a/docs/manual/security/index.md
+++ b/docs/manual/security/index.md
@@ -2,7 +2,7 @@
 
 Space Cloud leverages multiple security systems with the philosophy that applications and platforms should be secure by default. Treating security as an afterthought is a recipe for disaster.
 
-Every module in Space Cloud supports JWT-based authentication. It is disabled by default. This is because access to any database not specified in the configuration file is denied by default. Whenever possible, enable JWT-based authentication in production. You can check out the [official website](https://jwt.io) of the JWT project to learn more about it.
+Every module in Space Cloud supports JWT-based authentication. Access to any database not specified in the configuration file is denied by default. Whenever possible, use JWT-based authentication in production. You can check out the [official website](https://jwt.io) of the JWT project to learn more about it.
 
 ## How JWT are tokens used
 

--- a/docs/manual/security/index.md
+++ b/docs/manual/security/index.md
@@ -1,18 +1,20 @@
 # Securing your project
 
-There are several security provisions taken in Space Cloud. Our philosophy is to build applications and platforms which are secure by default. In today's world where security is given maximum priority, thinking of security as an after thought isn't possible.
+Space Cloud leverages multiple security systems with the philosophy that applications and platforms should be secure by default. Treating security as an afterthought is a recipe for disaster.
 
-Every module in Space Cloud uses JWT tokens for authentication. It is disabled by default. You can check out this [website](https://jwt.io) to learn more about JWT tokens. `space-cloud` looks for the JWT token in the `Authorization` header in each HTTP request made to it.
+Every module in Space Cloud supports JWT-based authentication. It is disabled by default. This is because access to any database not specified in the configuration file is denied by default. Whenever possible, enable JWT-based authentication in production. You can check out the [official website](https://jwt.io) of the JWT project to learn more about it.
 
-## How are JWT tokens used
+## How JWT are tokens used
+
+`space-cloud` looks for the JWT token in the `Authorization` header in each HTTP request made to it.
 
 The first stage where JWT tokens are used is to verify if the signature of the token is valid or not. This makes sure that the user is authenticate and has tried to change or create his / her own token. This stage is what we refer to as authentication. Every module (except user management) performs authentication.
 
-JWT tokens also contain a json object (known as claims) as a payload. The user is free to decide what claims must go into the JWT token. This json object is parsed and is made available as the `args.auth` variable in security rules. The integrity of the auth variable is maintained due to the nature of JWT tokens.
+JWT tokens also contain a JSON object (known as claims) as a payload. The user is free to decide what claims must go into the JWT token. This JSON object is parsed and is made available as the `args.auth` variable in security rules. The integrity of the auth variable is maintained due to the nature of JWT tokens.
 
 ## Security rules
 
-Security rules is a mechanism used to enforce authorization. The request is allowed to be made only if the conditions specified by the security rules are met. Currently the following rules are supported:
+Security rules are a mechanism used to enforce authorization. The request is allowed to be made only if the conditions specified by the security rules are met. Currently the following rules are supported:
 
 - **allow**: This rule is used to disable authentication and authorization entirely. The request is allowed to be made even if the JWT token is absent in the `Authorization` header.
 - **authenticated**: This rule is used to allow the request if a valid JWT token is found in the `Authorization`. No checks are imposed beyond that. Basically it authorizes every request which has passed the authentication stage.
@@ -22,7 +24,9 @@ Security rules is a mechanism used to enforce authorization. The request is allo
 - **and, or**: These rules helps you mix and match the `match` and `query` rules to tackle complex authorization tasks.
 
 ## Next steps
+
 Each module has their own way of using security rules. You can head over to the module specific security rule page to know more.
+
 - [Database](/docs/security/database)
 - [File storage](/docs/security/file-storage)
 


### PR DESCRIPTION
Two changes here:

* Make the console message printed on doc server startup a valid URL (e.g. `Documentation served from http://192.168.0.1:3000/docs`)
* Reword and expand some parts of the security overview doc

Happy to accept change requests. Thanks for your time.