### PR TITLE
No scrollbar visible in the docs pages [Patch]

### DIFF
--- a/docs/public/docs/sass/index/_content.scss
+++ b/docs/public/docs/sass/index/_content.scss
@@ -6,11 +6,11 @@
     @media #{$large-and-up} {
       position: absolute;
       top: 64px;
-      left: 300px;
+      left: 0;
       right: 0;
       bottom: 0;
       overflow: auto;
-      padding: 40px 0px 0px 60px;
+      padding: 40px 0px 0px 360px;
     }
 
     .docs-content {

--- a/docs/public/docs/sass/index/_sidebar.scss
+++ b/docs/public/docs/sass/index/_sidebar.scss
@@ -8,6 +8,7 @@
     background: $default-color;
     border-right: 1px solid $border-color;
     overflow: auto;
+    z-index: 1;
 
     @media #{$small-and-down} {
       display: none;

--- a/docs/public/index.handlebars
+++ b/docs/public/index.handlebars
@@ -185,7 +185,7 @@
     </div>
     <div class="content-wrapper">
       <div class="row" style="margin:0">
-        <div class="col s12 l6">
+        <div class="col s12 l8">
           <div class="docs-content">
             {{{html}}}
           </div>


### PR DESCRIPTION
created initial request here: https://github.com/YourTechBud/space-cloud/pull/1
 
[docs/public/docs/sass/index/_content.scss]
changes made to .main-wrapper {.content-wrapper{ 
-left property change to 0
-padding property changed to 40px 0px 0px 360px;

[docs/public/docs/sass/index/_sidebar.scss]
added a z-index of 1 to .main-wrapper >  .desktop-docs-sidebar
