### PR TITLE
Fix inconsistent Github URL #137

### DIFF
--- a/docs/public/index.handlebars
+++ b/docs/public/index.handlebars
@@ -204,7 +204,7 @@
               <div class="col s12 l5">
                 <div class="github-wrapper">
                   <p class="github-title open-source-text">Edit docs!</p>
-                  <a href="https://github.com/YourTechBud/space-cloud/tree/master/docs/manual"><img class="github-image"
+                  <a href="https://github.com/spaceuptech/space-cloud/tree/master/docs/manual"><img class="github-image"
                       src="/docs/images/index/github_black.svg" alt=""></a>
                 </div>
               </div>


### PR DESCRIPTION
Docs "edit docs!" footer and github url at navigation url different #137.

change endpoint
from:
https://github.com/YourTechBud/space-cloud/tree/master/docs/manual
proposed change:
https://github.com/spaceuptech/space-cloud/tree/master/docs/manual