### PR TITLE
Change connection-string for SQL-databases

### DIFF
--- a/config/generate.go
+++ b/config/generate.go
@@ -88,7 +88,7 @@ func getConnectionString(db string) string {
 	case string(utils.Mongo):
 		return "mongodb://localhost:27017"
 	case string(utils.MySQL):
-		return "root:my-secret-pw@/test"
+		return "user:my-secret-pwd@/project"
 	case string(utils.Postgres):
 		return "postgres://postgres:mysecretpassword@localhost/postgres?sslmode=disable"
 	default:

--- a/docs/manual/database/config.md
+++ b/docs/manual/database/config.md
@@ -47,7 +47,7 @@ modules:
             delete:
               rule: allow
     sql-mysql:
-      conn: root:my-secret-pw@/project
+      conn: user:my-secret-pwd@/project
       isPrimary: true
       collections:
         users:

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const buildVersion = "0.6.5"
+const buildVersion = "0.6.6"


### PR DESCRIPTION
Change connection-string for SQL-databases from "root:my-secret-pw@/test" to "user:my-secret-pwd@/project", so that login with the root account by default is prevented. This fixes #158. 