### PR TITLE
fix Var config collides with imported package name & actionInit param

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -39,14 +38,14 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:   "disable-metrics",
-					Usage:  "Disable annonymous metric collection",
+					Usage:  "Disable anonymous metric collection",
 					EnvVar: "DISABLE_METRICS",
 				},
 			},
 		},
 		{
 			Name:   "init",
-			Usage:  "creates a confg file with sensible defaults",
+			Usage:  "creates a config file with sensible defaults",
 			Action: actionInit,
 		},
 	}
@@ -68,11 +67,11 @@ func actionRun(c *cli.Context) error {
 	s := initServer(isProd)
 
 	if configPath != "none" {
-		config, err := config.LoadConfigFromFile(configPath)
+		conf, err := config.LoadConfigFromFile(configPath)
 		if err != nil {
 			return err
 		}
-		err = s.loadConfig(config)
+		err = s.loadConfig(conf)
 		if err != nil {
 			return err
 		}
@@ -84,10 +83,11 @@ func actionRun(c *cli.Context) error {
 	}
 
 	s.routes()
-	fmt.Println("Starting server on port " + port)
+	log.Println("Starting server on port ", port)
+
 	return s.start(port)
 }
 
-func actionInit(c *cli.Context) error {
+func actionInit(*cli.Context) error {
 	return config.GenerateConfig()
 }


### PR DESCRIPTION
fixes:
- Variable config collides with imported package name
- Remove unnecessary parameter and add Unnamed parameter as we won't refer to it explicitly 
- typos in cli
- add log as it has timestamp instead of fmt