### PR TITLE
take grpc port as parameter #169

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,11 @@ func main() {
 					Usage: "Start HTTP server on port `PORT`",
 				},
 				cli.StringFlag{
+					Name:  "grpc-port",
+					Value: "8081",
+					Usage: "Start grpc on port `GRPC_PORT`",
+				},
+				cli.StringFlag{
 					Name:  "config",
 					Value: "none",
 					Usage: "Load space cloud config from `FILE`",
@@ -59,6 +64,7 @@ func main() {
 func actionRun(c *cli.Context) error {
 	// Load cli flags
 	port := c.String("port")
+	grpcPort := c.String("grpc-port")
 	configPath := c.String("config")
 	isProd := c.Bool("prod")
 	disableMetrics := c.Bool("disable-metrics")
@@ -83,7 +89,7 @@ func actionRun(c *cli.Context) error {
 	}
 
 	s.routes()
-	return s.start(port)
+	return s.start(port, grpcPort)
 }
 
 func actionInit(*cli.Context) error {

--- a/server.go
+++ b/server.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -47,10 +46,9 @@ func initServer(isProd bool) *server {
 	return &server{router: r, auth: a, crud: c, user: u, file: f, faas: faas, realtime: realtime, isProd: isProd}
 }
 
-func (s *server) start(port string) error {
+func (s *server) start(port, grpcPort string) error {
 
-	portInt, _ := strconv.Atoi(port)
-	go s.initGRPCServer(strconv.Itoa(portInt + 1))
+	go s.initGRPCServer(grpcPort)
 
 	// Allow cors
 	corsObj := cors.New(cors.Options{

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const buildVersion = "0.7.1"
+const buildVersion = "0.8.0"


### PR DESCRIPTION
fixes #169 
I added  a new parameter `grpc-port` in client(main.go).