### PR TITLE
Fix/176 server url path for proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
     <a href="https://travis-ci.com/spaceuptech/space-cloud"><img
 		alt="Build Status"
 		src="https://travis-ci.com/spaceuptech/space-cloud.svg?branch=master"></a>
+	<a href="https://goreportcard.com/report/github.com/spaceuptech/space-cloud">
+		<img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/spaceuptech/space-cloud">
+	</a>
     <br/>
     <a href="https://opensource.org/licenses/Apache-2.0"><img
 		alt="Apache License"

--- a/routes.go
+++ b/routes.go
@@ -4,18 +4,18 @@ import "github.com/spaceuptech/space-cloud/config"
 
 func (s *server) routes() {
 	// Initialize the routes for config management
-	s.router.Methods("POST").Path("/v1/api/config").HandlerFunc(config.HandleConfig(s.isProd, s.loadConfig))
+	s.router.Methods("POST").Path("/api/v1/config").HandlerFunc(config.HandleConfig(s.isProd, s.loadConfig))
 
 	// Initialze the route for websocket
-	s.router.HandleFunc("/v1/api/socket/json", handleWebsocket(s.realtime, s.auth, s.crud))
+	s.router.HandleFunc("/api/v1/socket/json", handleWebsocket(s.realtime, s.auth, s.crud))
 
 	// Initialize the routes for faas engine
-	s.router.Methods("POST").Path("/v1/api/faas/{engine}/{func}").HandlerFunc(s.faas.HandleRequest(s.auth))
+	s.router.Methods("POST").Path("/api/v1/faas/{engine}/{func}").HandlerFunc(s.faas.HandleRequest(s.auth))
 
 	// Initialize the routes for the crud operations
-	s.router.Methods("POST").Path("/v1/api/{project}/crud/{dbType}/batch").HandlerFunc(s.handleBatch())
+	s.router.Methods("POST").Path("/api/v1/{project}/crud/{dbType}/batch").HandlerFunc(s.handleBatch())
 
-	crudRouter := s.router.Methods("POST").PathPrefix("/v1/api/{project}/crud/{dbType}/{col}").Subrouter()
+	crudRouter := s.router.Methods("POST").PathPrefix("/api/v1/{project}/crud/{dbType}/{col}").Subrouter()
 	crudRouter.HandleFunc("/create", s.handleCreate())
 	crudRouter.HandleFunc("/read", s.handleRead())
 	crudRouter.HandleFunc("/update", s.handleUpdate())
@@ -23,15 +23,15 @@ func (s *server) routes() {
 	crudRouter.HandleFunc("/aggr", s.handleAggregate())
 
 	// Initialize the routes for the user management operations
-	userRouter := s.router.PathPrefix("/v1/api/{project}/auth/{dbType}").Subrouter()
+	userRouter := s.router.PathPrefix("/api/v1/{project}/auth/{dbType}").Subrouter()
 	userRouter.Methods("POST").Path("/email/signin").HandlerFunc(s.user.HandleEmailSignIn())
 	userRouter.Methods("POST").Path("/email/signup").HandlerFunc(s.user.HandleEmailSignUp())
 	userRouter.Methods("GET").Path("/profile/{id}").HandlerFunc(s.user.HandleProfile())
 	userRouter.Methods("GET").Path("/profiles").HandlerFunc(s.user.HandleProfiles())
 
 	// Initialize the routes for the file management operations
-	s.router.Methods("POST").Path("/v1/api/{project}/files").HandlerFunc(s.file.HandleCreateFile(s.auth))
-	s.router.Methods("GET").PathPrefix("/v1/api/{project}/files").HandlerFunc(s.file.HandleRead(s.auth))
-	s.router.Methods("DELETE").PathPrefix("/v1/api/{project}/files").HandlerFunc(s.file.HandleDelete(s.auth))
+	s.router.Methods("POST").Path("/api/v1/{project}/files").HandlerFunc(s.file.HandleCreateFile(s.auth))
+	s.router.Methods("GET").PathPrefix("/api/v1/{project}/files").HandlerFunc(s.file.HandleRead(s.auth))
+	s.router.Methods("DELETE").PathPrefix("/api/v1/{project}/files").HandlerFunc(s.file.HandleDelete(s.auth))
 
 }


### PR DESCRIPTION
Put the versioning behind the /api-endpoint so that when configuring a proxy only one entpoint has to be configured for multiple versions. This fixes #176. 