### PR TITLE
added routes and proxy pass  support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,8 +97,15 @@ type FileRule struct {
 
 // Static holds the config for the static files module
 type Static struct {
-	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	Enabled bool           `json:"enabled" yaml:"enabled"`
+	Gzip    bool           `json:"gzip" yaml:"gzip"`
+	Routes  []*StaticRoute `json:"routes" yaml:"routes"`
+}
+
+// StaticRoute holds the config for each route
+type StaticRoute struct {
 	Path      string `json:"path" yaml:"path"`
 	URLPrefix string `json:"prefix" yaml:"prefix"`
-	Gzip      bool   `json:"gzip" yaml:"gzip"`
+	Host      string `json:"host" yaml:"host"`
+	Proxy     string `json:"proxy" yaml:"proxy"`
 }

--- a/config/template.go
+++ b/config/template.go
@@ -45,7 +45,8 @@ modules:
             rule: allow
   static:
     enabled: false
-    path: ./public
-    prefix: /
     gzip: false
+    routes:
+    - prefix: /
+      path: ./public
 `

--- a/modules/crud/sql/helpers.go
+++ b/modules/crud/sql/helpers.go
@@ -88,9 +88,7 @@ func mysqlTypeCheck(types []*sql.ColumnType, mapping map[string]interface{}) {
 		typeName := colType.DatabaseTypeName()
 		if typeName == "VARCHAR" || typeName == "TEXT" {
 			val, ok := mapping[colType.Name()].([]byte)
-			if !ok {
-				mapping[colType.Name()] = ""
-			} else {
+			if ok {
 				mapping[colType.Name()] = string(val)
 			}
 		}
@@ -101,7 +99,7 @@ func mysqlTypeCheck(types []*sql.ColumnType, mapping map[string]interface{}) {
 				log.Println("Error:", err)
 			}
 		}
-		if data, ok := mapping[colType.Name()].([]byte); (typeName == "DECIMAL") && ok {
+		if data, ok := mapping[colType.Name()].([]byte); (typeName == "DECIMAL" || typeName == "NUMERIC") && ok {
 			var err error
 			mapping[colType.Name()], err = strconv.ParseFloat(string(data), 64)
 			if err != nil {

--- a/modules/crud/sql/read.go
+++ b/modules/crud/sql/read.go
@@ -96,7 +96,7 @@ func (s *SQL) Read(ctx context.Context, project, col string, req *model.ReadRequ
 	var rowTypes []*sql.ColumnType
 
 	switch s.GetDBType() {
-	case utils.MySQL:
+	case utils.MySQL, utils.Postgres:
 		rowTypes, _ = rows.ColumnTypes()
 	}
 
@@ -113,7 +113,7 @@ func (s *SQL) Read(ctx context.Context, project, col string, req *model.ReadRequ
 		}
 
 		switch s.GetDBType() {
-		case utils.MySQL:
+		case utils.MySQL, utils.Postgres:
 			mysqlTypeCheck(rowTypes, mapping)
 		}
 
@@ -129,12 +129,12 @@ func (s *SQL) Read(ctx context.Context, project, col string, req *model.ReadRequ
 			}
 
 			switch s.GetDBType() {
-			case utils.MySQL:
+			case utils.MySQL, utils.Postgres:
 				rowTypes, _ = rows.ColumnTypes()
 			}
 
 			switch s.GetDBType() {
-			case utils.MySQL:
+			case utils.MySQL, utils.Postgres:
 				mysqlTypeCheck(rowTypes, mapping)
 			}
 

--- a/modules/static/http.go
+++ b/modules/static/http.go
@@ -1,14 +1,58 @@
 package static
 
 import (
+	"bufio"
 	"net/http"
-
-	"github.com/gorilla/mux"
+	"strings"
 )
 
 // HandleRequest creates a static request endpoint
-func (m *Module) HandleRequest(r *mux.Router) {
-	if m.Enabled {
-		r.PathPrefix(m.URLPrefix).Handler(http.FileServer(http.Dir(m.getDirPath())))
+func (m *Module) HandleRequest(w http.ResponseWriter, r *http.Request) {
+	url := r.URL.EscapedPath()
+	host := strings.Split(r.Host, ":")[0]
+
+	route, ok := m.selectRoute(host, url)
+	if !ok {
+		http.Error(w, "Path not found", http.StatusNotFound)
+		return
 	}
+
+	path := strings.TrimPrefix(url, route.URLPrefix)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	path = route.Path + path
+
+	// Its a proxy request
+	if route.Proxy != "" {
+		addr := route.Proxy + path
+		req, err := http.NewRequest(r.Method, addr, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
+		// Set the http headers
+		req.Header = make(http.Header)
+		if contentType, p := req.Header["Content-Type"]; p {
+			req.Header["Content_type"] = contentType
+		}
+
+		// Make the http client request
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer res.Body.Close()
+
+		reader := bufio.NewReader(res.Body)
+
+		w.Header().Set("Content-Type", res.Header.Get("Content-Type"))
+		w.WriteHeader(res.StatusCode)
+		reader.WriteTo(w)
+		return
+	}
+
+	http.ServeFile(w, r, path)
 }

--- a/modules/static/http.go
+++ b/modules/static/http.go
@@ -34,8 +34,8 @@ func (m *Module) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 		// Set the http headers
 		req.Header = make(http.Header)
-		if contentType, p := req.Header["Content-Type"]; p {
-			req.Header["Content_type"] = contentType
+		if contentType, p := r.Header["Content-Type"]; p {
+			req.Header["Content-Type"] = contentType
 		}
 
 		// Make the http client request

--- a/modules/static/static.go
+++ b/modules/static/static.go
@@ -59,10 +59,3 @@ func (m *Module) selectRoute(host, url string) (*config.StaticRoute, bool) {
 
 	return nil, false
 }
-
-func (m *Module) getDirPath(index int) string {
-	m.RLock()
-	defer m.RUnlock()
-
-	return m.routes[index].Path
-}

--- a/routes.go
+++ b/routes.go
@@ -37,5 +37,5 @@ func (s *server) routes() {
 	s.router.Methods("DELETE").PathPrefix("/v1/api/{project}/files").HandlerFunc(s.file.HandleDelete(s.auth))
 
 	// Initialize the route for handling static files
-	s.static.HandleRequest(s.router)
+	s.router.PathPrefix("/").HandlerFunc(s.static.HandleRequest)
 }


### PR DESCRIPTION
This lets us add the following functionality
- Use of space cloud as a simple reverse proxy
- Addition of routes to host static resources and proxy backend servers
- Replace NGINX for most standard deployments