### PR TITLE
Add a space cloud servers start up message

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,8 +120,8 @@ func actionRun(c *cli.Context) error {
 		}
 		server.DefaultNatsOptions.Port = natsPort
 		server.DefaultNatsOptions.Cluster.Port = clusterPort
+		fmt.Println("Starting NATS server on port:", server.DefaultNatsOptions.Port)
 		s.RunNatsServer(server.DefaultNatsOptions)
-		fmt.Println("Started NATS server on port ", server.DefaultNatsOptions.Port)
 	}
 
 	if configPath != "none" {

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -69,8 +69,9 @@ func (s *Server) Start(port, grpcPort string) error {
 
 	handler := corsObj.Handler(s.router)
 
-	fmt.Println("Starting http Server on port " + port)
+	fmt.Println("Starting HTTP Server on port: " + port)
 
+	log.Printf("Space Cloud is running on the specified ports...")
 	if s.config.SSL != nil {
 		return http.ListenAndServeTLS(":"+port, s.config.SSL.Crt, s.config.SSL.Key, handler)
 	}

--- a/utils/server/server.go
+++ b/utils/server/server.go
@@ -71,7 +71,7 @@ func (s *Server) Start(port, grpcPort string) error {
 
 	fmt.Println("Starting HTTP Server on port: " + port)
 
-	log.Printf("Space Cloud is running on the specified ports...")
+	log.Printf("Space Cloud is running on the specified ports :D")
 	if s.config.SSL != nil {
 		return http.ListenAndServeTLS(":"+port, s.config.SSL.Crt, s.config.SSL.Key, handler)
 	}


### PR DESCRIPTION
It's still not clear if Space Cloud servers are running or not (*at least that was the case for me*)

It should be more clear and consistent. And I think a timestamp when the servers started successfully should be shown. Hence this pr. 