### PR TITLE
Sync man module optimisations

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -146,6 +146,12 @@ func main() {
 			Name:   "health-check",
 			Usage:  "check the health of gateway instance",
 			Action: actionHealthCheck,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "timeout",
+					Value: 3,
+				},
+			},
 		},
 	}
 
@@ -233,7 +239,7 @@ func actionRun(c *cli.Context) error {
 }
 
 func actionHealthCheck(c *cli.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.Int("timeout"))*time.Second)
 	defer cancel()
 
 	// Make a request object

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -149,7 +149,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.IntFlag{
 					Name:  "timeout",
-					Value: 3,
+					Value: 5,
 				},
 			},
 		},

--- a/gateway/managers/syncman/helpers.go
+++ b/gateway/managers/syncman/helpers.go
@@ -81,7 +81,293 @@ func splitResourceID(ctx context.Context, resourceID string) (clusterID string, 
 	return arr[0], arr[1], config.Resource(arr[2]), nil
 }
 
-func validateResource(ctx context.Context, eventType string, globalConfig *config.Config, resourceID string, resourceType config.Resource, resource interface{}) error {
+func (s *Manager) validateResource(ctx context.Context, eventType string, resourceID string, resourceType config.Resource, resource interface{}) (bool, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	globalConfig := s.projectConfig
+
+	_, projectID, rt, err := splitResourceID(ctx, resourceID)
+	if err != nil {
+		return false, err
+	}
+
+	// if resource type not provided extract in from resource id
+	if resourceType == "" {
+		resourceType = rt
+	}
+
+	// check cluster level resources first
+	switch resourceType {
+	case config.ResourceCluster:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.ClusterConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.ClusterConfig{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(globalConfig.ClusterConfig, value) {
+				return true, nil
+			}
+		}
+		return false, nil
+
+	case config.ResourceIntegration:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.IntegrationConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.IntegrationConfig{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(globalConfig.Integrations[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+
+	case config.ResourceIntegrationHook:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.IntegrationHook)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.IntegrationHook{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(globalConfig.IntegrationHooks[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+
+	}
+
+	if resourceType == config.ResourceProject {
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.ProjectConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(globalConfig.Projects[projectID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	project, ok := globalConfig.Projects[projectID]
+	if !ok {
+		_ = helpers.Logger.LogError(helpers.GetRequestID(context.TODO()), "Unable to find project", err, map[string]interface{}{"project": projectID})
+		return false, nil
+	}
+
+	switch resourceType {
+	case config.ResourceAuthProvider:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.AuthStub)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.Auths[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceDatabaseConfig:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.DatabaseConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.DatabaseConfigs[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceDatabaseSchema:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.DatabaseSchema)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.DatabaseSchemas[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceDatabaseRule:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.DatabaseRule)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.DatabaseRules[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceDatabasePreparedQuery:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.DatbasePreparedQuery)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.DatabasePreparedQueries[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceEventingConfig:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.EventingConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.EventingConfig, value) {
+				return true, nil
+			}
+
+		}
+		return false, nil
+	case config.ResourceEventingSchema:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.EventingSchema)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.EventingSchemas[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceEventingRule:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.Rule)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.EventingRules[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceEventingTrigger:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.EventingTrigger)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.EventingTriggers[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceFileStoreConfig:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.FileStoreConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.FileStoreConfig, value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceFileStoreRule:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.FileRule)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.FileStoreRules[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceProjectLetsEncrypt:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.LetsEncrypt)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.LetsEncrypt, value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceIngressRoute:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.Route)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.IngressRoutes[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceIngressGlobal:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.GlobalRoutesConfig)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.IngressGlobal, value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case config.ResourceRemoteService:
+		switch eventType {
+		case config.ResourceAddEvent, config.ResourceUpdateEvent:
+			value := new(config.Service)
+			if err := mapstructure.Decode(resource, value); err != nil {
+				return false, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("invalid type provided for resource (%s) expecting (%v) got (%v)", resourceType, "config.Auth{}", reflect.TypeOf(resource)), nil, nil)
+			}
+
+			if reflect.DeepEqual(project.RemoteService[resourceID], value) {
+				return true, nil
+			}
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown resource type (%s) provided", resourceType)
+	}
+}
+
+// NOTE: any change made in this function should also be reflected into validateResource() method of sync man
+func updateResource(ctx context.Context, eventType string, globalConfig *config.Config, resourceID string, resourceType config.Resource, resource interface{}) error {
 	if globalConfig == nil {
 		return helpers.Logger.LogError(helpers.GetRequestID(ctx), "Cannot provide empty value for config", nil, nil)
 	}

--- a/gateway/managers/syncman/store_kube.go
+++ b/gateway/managers/syncman/store_kube.go
@@ -214,7 +214,7 @@ func (s *KubeStore) SetResource(ctx context.Context, resourceID string, resource
 	}
 
 	// validate if the resource value is according to the resource type
-	if err := validateResource(ctx, config.ResourceAddEvent, s.projectsConfig, resourceID, resourceType, resource); err != nil {
+	if err := updateResource(ctx, config.ResourceAddEvent, s.projectsConfig, resourceID, resourceType, resource); err != nil {
 		return helpers.Logger.LogError(helpers.GetRequestID(ctx), "Unable to validate resource", err, map[string]interface{}{"project": projectID})
 	}
 
@@ -282,7 +282,7 @@ func (s *KubeStore) GetGlobalConfig() (*config.Config, error) {
 		}
 		for _, configMap := range configMaps.Items {
 			eventType, resourceID, _, resource := onAddOrUpdateResource(config.ResourceAddEvent, &configMap)
-			if err := validateResource(context.TODO(), eventType, globalConfig, resourceID, resourceType, resource); err != nil {
+			if err := updateResource(context.TODO(), eventType, globalConfig, resourceID, resourceType, resource); err != nil {
 				return nil, err
 			}
 		}

--- a/gateway/managers/syncman/store_local.go
+++ b/gateway/managers/syncman/store_local.go
@@ -55,7 +55,7 @@ func (s *LocalStore) WatchServices(cb func(scServices)) error {
 
 // SetResource sets the project of the local globalConfig
 func (s *LocalStore) SetResource(ctx context.Context, resourceID string, resource interface{}) error {
-	if err := validateResource(ctx, config.ResourceAddEvent, s.globalConfig, resourceID, "", resource); err != nil {
+	if err := updateResource(ctx, config.ResourceAddEvent, s.globalConfig, resourceID, "", resource); err != nil {
 		return err
 	}
 	return config.StoreConfigToFile(s.globalConfig, s.configPath)
@@ -63,7 +63,7 @@ func (s *LocalStore) SetResource(ctx context.Context, resourceID string, resourc
 
 // DeleteResource deletes the project from the local gloablConfig
 func (s *LocalStore) DeleteResource(ctx context.Context, resourceID string) error {
-	if err := validateResource(ctx, config.ResourceDeleteEvent, s.globalConfig, resourceID, "", nil); err != nil {
+	if err := updateResource(ctx, config.ResourceDeleteEvent, s.globalConfig, resourceID, "", nil); err != nil {
 		return err
 	}
 	return config.StoreConfigToFile(s.globalConfig, s.configPath)

--- a/gateway/model/request.go
+++ b/gateway/model/request.go
@@ -25,6 +25,7 @@ type SpecObject struct {
 	Spec interface{}       `json:"spec" yaml:"spec,omitempty"`
 }
 
+// BatchSpecApplyRequest body of batch config apply endpoint
 type BatchSpecApplyRequest struct {
 	Specs []*SpecObject `json:"specs" yaml:"specs"`
 }

--- a/gateway/model/request.go
+++ b/gateway/model/request.go
@@ -16,3 +16,15 @@ type RequestParams struct {
 	Path       string                 `json:"path"`
 	Payload    interface{}            `json:"payload"`
 }
+
+// SpecObject describes the basic structure of config specifications
+type SpecObject struct {
+	API  string            `json:"api" yaml:"api"`
+	Type string            `json:"type" yaml:"type"`
+	Meta map[string]string `json:"meta" yaml:"meta"`
+	Spec interface{}       `json:"spec" yaml:"spec,omitempty"`
+}
+
+type BatchSpecApplyRequest struct {
+	Specs []*SpecObject `json:"specs" yaml:"specs"`
+}

--- a/gateway/server/handlers/config_batch.go
+++ b/gateway/server/handlers/config_batch.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/spaceuptech/helpers"
+
+	"github.com/spaceuptech/space-cloud/gateway/managers/admin"
+	"github.com/spaceuptech/space-cloud/gateway/model"
+	"github.com/spaceuptech/space-cloud/gateway/utils"
+)
+
+// HandleBatchApplyConfig applies all the config at once
+func HandleBatchApplyConfig(adminMan *admin.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := utils.GetTokenFromHeader(r)
+
+		req := new(model.BatchSpecApplyRequest)
+		_ = json.NewDecoder(r.Body).Decode(req)
+		defer utils.CloseTheCloser(r.Body)
+
+		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(utils.DefaultContextTime)*time.Second)
+		defer cancel()
+
+		_, err := adminMan.IsTokenValid(ctx, token, "batch-apply", "modify", map[string]string{})
+		if err != nil {
+			_ = helpers.Response.SendErrorResponse(ctx, w, http.StatusUnauthorized, err.Error())
+			return
+		}
+
+		for _, specObject := range req.Specs {
+			if err := utils.ApplySpec(ctx, token, "http://localhost:4122", specObject); err != nil {
+				_ = helpers.Response.SendErrorResponse(ctx, w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+
+		_ = helpers.Response.SendOkayResponse(ctx, http.StatusOK, w)
+	}
+}

--- a/gateway/server/handlers/config_batch.go
+++ b/gateway/server/handlers/config_batch.go
@@ -25,8 +25,7 @@ func HandleBatchApplyConfig(adminMan *admin.Manager) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), time.Duration(utils.DefaultContextTime)*time.Second)
 		defer cancel()
 
-		_, err := adminMan.IsTokenValid(ctx, token, "batch-apply", "modify", map[string]string{})
-		if err != nil {
+		if err := adminMan.CheckIfAdmin(ctx, token); err != nil {
 			_ = helpers.Response.SendErrorResponse(ctx, w, http.StatusUnauthorized, err.Error())
 			return
 		}

--- a/gateway/server/routes.go
+++ b/gateway/server/routes.go
@@ -92,6 +92,8 @@ func (s *Server) routes(profiler bool, staticPath string, restrictedHosts []stri
 	router.Methods(http.MethodPost).Path("/v1/config/projects/{project}/routing/ingress/{id}").HandlerFunc(handlers.HandleSetProjectRoute(s.managers.Admin(), s.managers.Sync()))
 	router.Methods(http.MethodDelete).Path("/v1/config/projects/{project}/routing/ingress/{id}").HandlerFunc(handlers.HandleDeleteProjectRoute(s.managers.Admin(), s.managers.Sync()))
 
+	router.Methods(http.MethodPost).Path("/v1/config/batch-apply").HandlerFunc(handlers.HandleBatchApplyConfig(s.managers.Admin()))
+
 	// Health check
 	router.Methods(http.MethodGet).Path("/v1/api/health-check").HandlerFunc(handlers.HandleHealthCheck(s.managers.Sync()))
 

--- a/gateway/utils/apply_config.go
+++ b/gateway/utils/apply_config.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spaceuptech/helpers"
+	"golang.org/x/net/context"
+
+	"github.com/spaceuptech/space-cloud/gateway/model"
+)
+
+// ApplySpec takes a spec object and applies it
+func ApplySpec(ctx context.Context, token, hostAddr string, specObj *model.SpecObject) error {
+	requestBody, err := json.Marshal(specObj.Spec)
+	if err != nil {
+		return helpers.Logger.LogError(helpers.GetRequestID(ctx), "error while applying service unable to marshal spec", err, nil)
+	}
+	url, err := adjustPath(fmt.Sprintf("%s%s", hostAddr, specObj.API), specObj.Meta)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return helpers.Logger.LogError(helpers.GetRequestID(ctx), "error while applying service unable to send http request", err, nil)
+	}
+
+	v := map[string]interface{}{}
+	_ = json.NewDecoder(resp.Body).Decode(&v)
+	CloseTheCloser(req.Body)
+
+	if resp.StatusCode == http.StatusAccepted {
+		// Make checker send this status
+		helpers.Logger.LogInfo(helpers.GetRequestID(ctx), fmt.Sprintf("Successfully queued %s", specObj.Type), nil)
+	} else if resp.StatusCode == http.StatusOK {
+		helpers.Logger.LogInfo(helpers.GetRequestID(ctx), fmt.Sprintf("Successfully applied %s", specObj.Type), nil)
+	} else {
+		_ = helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("error while applying service got http status code %s", resp.Status), fmt.Errorf("%s", v["error"]), nil)
+		return fmt.Errorf("%v", v["error"])
+	}
+	return nil
+}
+
+func adjustPath(path string, meta map[string]string) (string, error) {
+	newPath := path
+	for {
+		pre := strings.IndexRune(newPath, '{')
+		if pre < 0 {
+			return newPath, nil
+		}
+		post := strings.IndexRune(newPath, '}')
+
+		key := strings.TrimSuffix(strings.TrimPrefix(newPath[pre:post], "{"), "}")
+		value, p := meta[key]
+		if !p {
+			return "", fmt.Errorf("provided key (%s) does not exist in metadata", key)
+		}
+
+		newPath = newPath[:pre] + value + newPath[post+1:]
+	}
+}

--- a/gateway/utils/graphql/func.go
+++ b/gateway/utils/graphql/func.go
@@ -39,8 +39,12 @@ func (graph *Module) execFuncCall(ctx context.Context, token string, field *ast.
 	}
 
 	go func() {
-		ctx2, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-		defer cancel()
+		var ctx2 = ctx
+		if timeout != 0 {
+			c, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+			defer cancel()
+			ctx2 = c
+		}
 
 		_, result, err := graph.functions.CallWithContext(ctx2, serviceName, funcName, token, reqParams, params)
 		_ = graph.auth.PostProcessMethod(ctx, actions, result)
@@ -94,7 +98,7 @@ func getFuncTimeout(ctx context.Context, field *ast.Field, store utils.M) (int, 
 			}
 		}
 	}
-	return 5, nil
+	return 0, nil
 }
 
 func getFuncParams(ctx context.Context, field *ast.Field, store utils.M) (map[string]interface{}, error) {

--- a/install-manifests/helm/space-cloud/templates/05-gateway.yaml
+++ b/install-manifests/helm/space-cloud/templates/05-gateway.yaml
@@ -192,8 +192,9 @@ spec:
               command:
                 - ./app
                 - health-check
-            initialDelaySeconds: 100
-            periodSeconds: 10
+                - -timeout={{ .Values.gateway.healthCheck.timeout }}
+            initialDelaySeconds: {{ .Values.gateway.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.gateway.healthCheck.periodSeconds }}
           env:
             - name: "NODE_ID"
               valueFrom:

--- a/install-manifests/helm/space-cloud/values.yaml
+++ b/install-manifests/helm/space-cloud/values.yaml
@@ -18,6 +18,10 @@ meta:
 
 # Gateway service configuration
 gateway:
+  healthCheck:
+    initialDelaySeconds: 100 # tells the kubelet that it should wait 100 seconds before performing the first health check.
+    periodSeconds: 10 # field specifies that the kubelet should perform a liveness probe every 10 seconds.
+    timeout: 3 # http request timeout, it should be less than (periodSeconds)
   image:
     name: "spaceuptech/gateway"
     pullPolicy: "IfNotPresent" # IfNotPresent | Always

--- a/install-manifests/helm/space-cloud/values.yaml
+++ b/install-manifests/helm/space-cloud/values.yaml
@@ -21,7 +21,7 @@ gateway:
   healthCheck:
     initialDelaySeconds: 100 # tells the kubelet that it should wait 100 seconds before performing the first health check.
     periodSeconds: 10 # field specifies that the kubelet should perform a liveness probe every 10 seconds.
-    timeout: 3 # http request timeout, it should be less than (periodSeconds)
+    timeout: 5 # http request timeout, it should be less than (periodSeconds)
   image:
     name: "spaceuptech/gateway"
     pullPolicy: "IfNotPresent" # IfNotPresent | Always


### PR DESCRIPTION
1) Config watcher now checks for duplicate config, immediately returns if duplicate found
2) Gateway health checks are configurable, updated helm chart
3) Added batch config apply endpoint
4) Removed the default 5 second context of graphql