### PR TITLE
Service request retries & timeouts

### DIFF
--- a/gateway/modules/crud/dataloader.go
+++ b/gateway/modules/crud/dataloader.go
@@ -78,7 +78,6 @@ func (holder *resultsHolder) fillResults(res []interface{}) {
 		// Get the where clause
 		meta := holder.metas[index]
 		isOperationTypeOne := meta.op == utils.One
-		var result interface{}
 		docs := make([]interface{}, 0)
 		for _, doc := range res {
 			if utils.Validate(meta.whereClause, doc) {
@@ -92,11 +91,12 @@ func (holder *resultsHolder) fillResults(res []interface{}) {
 		// Increment the where clause index
 		index++
 
+		var result interface{}
 		if isOperationTypeOne {
-			if len(docs) >= 1 {
+			if len(docs) > 0 {
 				result = docs[0]
 			} else {
-				result = map[string]interface{}{}
+				result = nil
 			}
 		} else {
 			result = docs

--- a/gateway/utils/graphql/read.go
+++ b/gateway/utils/graphql/read.go
@@ -183,8 +183,13 @@ func (graph *Module) execPreparedQueryRequest(ctx context.Context, field *ast.Fi
 func generateReadRequest(ctx context.Context, field *ast.Field, store utils.M) (*model.ReadRequest, bool, error) {
 	var err error
 
+	op, err := extractQueryOp(ctx, field.Arguments, store)
+	if err != nil {
+		return nil, false, err
+	}
+
 	// Create a read request object
-	readRequest := model.ReadRequest{Operation: utils.All, Options: new(model.ReadOptions), PostProcess: map[string]*model.PostProcess{}}
+	readRequest := model.ReadRequest{Operation: op, Options: new(model.ReadOptions), PostProcess: map[string]*model.PostProcess{}}
 
 	readRequest.Find, err = ExtractWhereClause(field.Arguments, store)
 	if err != nil {
@@ -480,6 +485,25 @@ func getAggregateArguments(field *ast.Directive, store utils.M) (string, string,
 	}
 
 	return operation, fieldName, nil
+}
+
+func extractQueryOp(ctx context.Context, args []*ast.Argument, store utils.M) (string, error) {
+	for _, v := range args {
+		switch v.Name.Value {
+		case "op":
+			temp, err := utils.ParseGraphqlValue(v.Value, store)
+			if err != nil {
+				return "", err
+			}
+			switch temp.(string) {
+			case utils.All, utils.One:
+				return temp.(string), nil
+			default:
+				return "", helpers.Logger.LogError(helpers.GetRequestID(ctx), "Invalid value provided for field (op)", nil, nil)
+			}
+		}
+	}
+	return utils.All, nil
 }
 
 func extractGroupByClause(ctx context.Context, args []*ast.Argument, store utils.M) ([]interface{}, error) {

--- a/runner/model/routing.go
+++ b/runner/model/routing.go
@@ -8,14 +8,21 @@ import (
 	"github.com/spaceuptech/helpers"
 )
 
+const (
+	DefaultRequestRetries int32 = 3
+	DefaultRequestTimeout int64 = 180 // Time in seconds
+)
+
 // Routes describes the configuration for the routing module
 type Routes []*Route
 
 // Route describes the parameters of a single route
 type Route struct {
-	ID      string        `json:"id" yaml:"id"`
-	Source  RouteSource   `json:"source" yaml:"source"`
-	Targets []RouteTarget `json:"targets" yaml:"targets"`
+	ID             string        `json:"id" yaml:"id"`
+	RequestRetries int32         `json:"requestRetries" yaml:"requestRetries"`
+	RequestTimeout int64         `json:"requestTimeout" yaml:"requestTimeout"`
+	Source         RouteSource   `json:"source" yaml:"source"`
+	Targets        []RouteTarget `json:"targets" yaml:"targets"`
 }
 
 // SelectTarget returns a target based on the weights assigned

--- a/runner/model/routing.go
+++ b/runner/model/routing.go
@@ -9,7 +9,9 @@ import (
 )
 
 const (
+	// DefaultRequestRetries specifies the default values of service request retries
 	DefaultRequestRetries int32 = 3
+	// DefaultRequestTimeout specifies the default values of service request timeouts
 	DefaultRequestTimeout int64 = 180 // Time in seconds
 )
 


### PR DESCRIPTION
1) Graphql now supports op argument to return an only single result, Fixes #1437 
2) Added the ability to specify request retries & timeout for services deployed through space cloud, Fixes #1173 