### PR TITLE
Removed auto generate ID functionality if the field is nullable.

### DIFF
--- a/gateway/modules/schema/helpers/operations.go
+++ b/gateway/modules/schema/helpers/operations.go
@@ -48,18 +48,15 @@ func SchemaValidator(ctx context.Context, dbAlias, dbType, col string, collectio
 			ok = true
 		}
 
-		if fieldValue.Kind == model.TypeID && !ok {
-			value = ksuid.New().String()
-			ok = true
-		}
-
 		if fieldValue.IsCreatedAt || fieldValue.IsUpdatedAt {
 			mutatedDoc[fieldKey] = time.Now().UTC()
 			continue
 		}
 
 		if fieldValue.IsFieldTypeRequired {
-			if !ok {
+			if fieldValue.Kind == model.TypeID && !ok {
+				value = ksuid.New().String()
+			} else if !ok {
 				return nil, errors.New("required field " + fieldKey + " from " + col + " not present in request")
 			}
 		}

--- a/gateway/utils/graphql/create.go
+++ b/gateway/utils/graphql/create.go
@@ -44,7 +44,7 @@ func (graph *Module) prepareDocs(doc map[string]interface{}, schemaFields model.
 	fieldDefaults := make(map[string]interface{})
 
 	for fieldName, fieldSchema := range schemaFields {
-		// ignore nullable id fields
+		// Only process ID fields which are required
 		if fieldSchema.Kind == model.TypeID && fieldSchema.IsFieldTypeRequired {
 			fieldIDs = append(fieldIDs, fieldName)
 		}

--- a/gateway/utils/graphql/create.go
+++ b/gateway/utils/graphql/create.go
@@ -44,7 +44,8 @@ func (graph *Module) prepareDocs(doc map[string]interface{}, schemaFields model.
 	fieldDefaults := make(map[string]interface{})
 
 	for fieldName, fieldSchema := range schemaFields {
-		if fieldSchema.Kind == model.TypeID {
+		// ignore nullable id fields
+		if fieldSchema.Kind == model.TypeID && fieldSchema.IsFieldTypeRequired {
 			fieldIDs = append(fieldIDs, fieldName)
 		}
 


### PR DESCRIPTION
1) From now onwards, If a field in a schema has a type of ID which is not null. Then space cloud will not auto-generate ID for that field. For auto-generate to work, you have make the field required by adding (!) in the schema.

Fixes #1496 