### PR TITLE
Added name data type in postgres

### DIFF
--- a/gateway/modules/crud/sql/helpers.go
+++ b/gateway/modules/crud/sql/helpers.go
@@ -187,7 +187,8 @@ func mysqlTypeCheck(ctx context.Context, dbType model.DBType, types []*sql.Colum
 				if err := json.Unmarshal(v, &val); err == nil {
 					mapping[colType.Name()] = val
 				}
-			case "VARCHAR", "TEXT":
+			case "VARCHAR", "TEXT", "NAME":
+				// NOTE: The NAME data type is only valid for Postgres database, as it exists for Postgres only (Name is a 63 byte (varchar) type used for storing system identifiers.)
 				val, ok := mapping[colType.Name()].([]byte)
 				if ok {
 					mapping[colType.Name()] = string(val)

--- a/gateway/modules/schema/inspection.go
+++ b/gateway/modules/schema/inspection.go
@@ -268,7 +268,7 @@ func inspectionPostgresCheckFieldType(field model.InspectorFieldType, fieldDetai
 				Precision: field.DateTimePrecision,
 			}
 		}
-	case "character", "bit", "text":
+	case "character", "bit", "text", "name":
 		fieldDetails.Kind = model.TypeString
 	case "bigint", "bigserial", "integer", "smallint", "smallserial", "serial":
 		fieldDetails.Kind = model.TypeInteger


### PR DESCRIPTION
1) Added data type called NAME in inspection & sql type check function. This data type is only available in postgres. For more info (https://dba.stackexchange.com/questions/217533/what-is-the-data-type-name-in-postgresql)