### PR TITLE
Added traffic splitting based on headers & URLs

### DIFF
--- a/runner/model/routing.go
+++ b/runner/model/routing.go
@@ -61,7 +61,7 @@ type HTTPMatcher struct {
 	Key          string             `json:"key,omitempty" yaml:"key,omitempty"`
 	Value        string             `json:"value,omitempty" yaml:"value,omitempty"`
 	Type         RouteHTTPMatchType `json:"type,omitempty" yaml:"type,omitempty"`
-	IsIgnoreCase bool               `json:"isIgnoreCase,omitempty" yaml:"isIgnoreCase,omitempty"`
+	IgnoreCase bool               `json:"ignoreCase,omitempty" yaml:"ignoreCase,omitempty"`
 }
 
 // RouteSource is the source of routing

--- a/runner/model/routing.go
+++ b/runner/model/routing.go
@@ -23,6 +23,7 @@ type Route struct {
 	ID             string        `json:"id" yaml:"id"`
 	RequestRetries int32         `json:"requestRetries" yaml:"requestRetries"`
 	RequestTimeout int64         `json:"requestTimeout" yaml:"requestTimeout"`
+	Matchers       []*Matcher    `json:"matchers" yaml:"matchers"`
 	Source         RouteSource   `json:"source" yaml:"source"`
 	Targets        []RouteTarget `json:"targets" yaml:"targets"`
 }
@@ -47,6 +48,20 @@ func (r *Route) SelectTarget(ctx context.Context, weight int32) (RouteTarget, er
 
 	// Return error if no targets match
 	return RouteTarget{}, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("No target found for route (%s) - make sure you have defined atleast one target with proper weights", r.Source.URL), nil, nil)
+}
+
+// Matcher store the rules, which are used for traffic splitting between service
+type Matcher struct {
+	URL     *HTTPMatcher   `json:"url,omitempty" yaml:"url,omitempty"`
+	Headers []*HTTPMatcher `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+// HTTPMatcher is matcher type
+type HTTPMatcher struct {
+	Key          string             `json:"key,omitempty" yaml:"key,omitempty"`
+	Value        string             `json:"value,omitempty" yaml:"value,omitempty"`
+	Type         RouteHTTPMatchType `json:"type,omitempty" yaml:"type,omitempty"`
+	IsIgnoreCase bool               `json:"isIgnoreCase,omitempty" yaml:"isIgnoreCase,omitempty"`
 }
 
 // RouteSource is the source of routing
@@ -89,4 +104,18 @@ const (
 
 	// RouteTargetExternal is used to route to external services
 	RouteTargetExternal RouteTargetType = "external"
+)
+
+// RouteHTTPMatchType defines http match type
+type RouteHTTPMatchType string
+
+const (
+	// RouteHTTPMatchTypeExact is used for exact match
+	RouteHTTPMatchTypeExact RouteHTTPMatchType = "exact"
+	// RouteHTTPMatchTypeRegex is used for regex match
+	RouteHTTPMatchTypeRegex RouteHTTPMatchType = "regex"
+	// RouteHTTPMatchTypePrefix is used for prefix match
+	RouteHTTPMatchTypePrefix RouteHTTPMatchType = "prefix"
+	// RouteHTTPMatchTypeCheckPresence is used for only checking the presence of header in the http request
+	RouteHTTPMatchTypeCheckPresence RouteHTTPMatchType = "check-presence"
 )

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -303,7 +303,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 
 					if exact := headerValue.GetExact(); exact != "" {
 						tempHeader.Type = model.RouteHTTPMatchTypeExact
-						tempHeader.Value = headerValue.GetExact()
+						tempHeader.Value = exact
 					}
 					if prefix := headerValue.GetPrefix(); prefix != "" {
 						tempHeader.Type = model.RouteHTTPMatchTypePrefix

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -288,7 +288,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 					}
 					if prefix := match.Uri.GetPrefix(); prefix != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypePrefix
-						tempMatcher.URL.Value = match.Uri.GetPrefix()
+						tempMatcher.URL.Value = prefix
 					}
 					if regex := match.Uri.GetRegex(); regex != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypeRegex

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -279,9 +279,9 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 			for i, match := range route.Match {
 				tempMatcher := new(model.Matcher)
 
-				if  math.Uri != nil && match.Uri.GetMatchType() != nil {
+				if match.Uri != nil && match.Uri.GetMatchType() != nil {
 					tempMatcher.URL = new(model.HTTPMatcher)
-					tempMatcher.URL.IsIgnoreCase = match.IgnoreUriCase
+					tempMatcher.URL.IgnoreCase = match.IgnoreUriCase
 					if exact := match.Uri.GetExact(); exact != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypeExact
 						tempMatcher.URL.Value = exact

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -311,7 +311,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 					}
 					if regex := headerValue.GetRegex(); regex != "" {
 						tempHeader.Type = model.RouteHTTPMatchTypeRegex
-						tempHeader.Value = headerValue.GetRegex()
+						tempHeader.Value = regex
 					}
 
 					if tempHeader.Value == "" || tempHeader.Type == "" {

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -279,7 +279,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 			for i, match := range route.Match {
 				tempMatcher := new(model.Matcher)
 
-				if match.Uri.GetMatchType() != nil {
+				if  math.Uri != nil && match.Uri.GetMatchType() != nil {
 					tempMatcher.URL = new(model.HTTPMatcher)
 					tempMatcher.URL.IsIgnoreCase = match.IgnoreUriCase
 					if exact := match.Uri.GetExact(); exact != "" {

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -284,7 +284,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 					tempMatcher.URL.IsIgnoreCase = match.IgnoreUriCase
 					if exact := match.Uri.GetExact(); exact != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypeExact
-						tempMatcher.URL.Value = match.Uri.GetExact()
+						tempMatcher.URL.Value = exact
 					}
 					if prefix := match.Uri.GetPrefix(); prefix != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypePrefix

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -307,7 +307,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 					}
 					if prefix := headerValue.GetPrefix(); prefix != "" {
 						tempHeader.Type = model.RouteHTTPMatchTypePrefix
-						tempHeader.Value = headerValue.GetPrefix()
+						tempHeader.Value = prefix
 					}
 					if regex := headerValue.GetRegex(); regex != "" {
 						tempHeader.Type = model.RouteHTTPMatchTypeRegex

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -269,12 +269,60 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 
 	for _, service := range services.Items {
 		serviceID := service.Labels["app"]
-		routes := make(model.Routes, len(service.Spec.Http)+len(service.Spec.Tcp))
+		routes := make(model.Routes, 0)
 
-		for i, route := range service.Spec.Http {
+		for _, route := range service.Spec.Http {
 
 			// Generate the targets
 			targets := make([]model.RouteTarget, len(route.Route))
+			matchers := make([]*model.Matcher, len(route.Match))
+			for i, match := range route.Match {
+				tempMatcher := new(model.Matcher)
+
+				if match.Uri.GetMatchType() != nil {
+					tempMatcher.URL = new(model.HTTPMatcher)
+					tempMatcher.URL.IsIgnoreCase = match.IgnoreUriCase
+					if exact := match.Uri.GetExact(); exact != "" {
+						tempMatcher.URL.Type = model.RouteHTTPMatchTypeExact
+						tempMatcher.URL.Value = match.Uri.GetExact()
+					}
+					if prefix := match.Uri.GetPrefix(); prefix != "" {
+						tempMatcher.URL.Type = model.RouteHTTPMatchTypePrefix
+						tempMatcher.URL.Value = match.Uri.GetPrefix()
+					}
+					if regex := match.Uri.GetRegex(); regex != "" {
+						tempMatcher.URL.Type = model.RouteHTTPMatchTypeRegex
+						tempMatcher.URL.Value = match.Uri.GetRegex()
+					}
+				}
+
+				tempMatcher.Headers = make([]*model.HTTPMatcher, 0)
+				for headerKey, headerValue := range match.Headers {
+					tempHeader := new(model.HTTPMatcher)
+					tempHeader.Key = headerKey
+
+					if exact := headerValue.GetExact(); exact != "" {
+						tempHeader.Type = model.RouteHTTPMatchTypeExact
+						tempHeader.Value = headerValue.GetExact()
+					}
+					if prefix := headerValue.GetPrefix(); prefix != "" {
+						tempHeader.Type = model.RouteHTTPMatchTypePrefix
+						tempHeader.Value = headerValue.GetPrefix()
+					}
+					if regex := headerValue.GetRegex(); regex != "" {
+						tempHeader.Type = model.RouteHTTPMatchTypeRegex
+						tempHeader.Value = headerValue.GetRegex()
+					}
+
+					if tempHeader.Value == "" || tempHeader.Type == "" {
+						tempHeader.Type = model.RouteHTTPMatchTypeCheckPresence
+					}
+
+					tempMatcher.Headers = append(tempMatcher.Headers, tempHeader)
+				}
+				matchers[i] = tempMatcher
+			}
+
 			for j, destination := range route.Route {
 				target := model.RouteTarget{Weight: destination.Weight}
 
@@ -307,10 +355,10 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 			}
 
 			// Set the route
-			routes[i] = &model.Route{ID: serviceID, RequestTimeout: route.Retries.PerTryTimeout.Seconds, RequestRetries: route.Retries.Attempts, Source: model.RouteSource{Port: int32(route.Match[0].Port), Protocol: model.HTTP}, Targets: targets}
+			routes = append(routes, &model.Route{ID: serviceID, RequestTimeout: route.Retries.PerTryTimeout.Seconds, RequestRetries: route.Retries.Attempts, Source: model.RouteSource{Port: int32(route.Match[0].Port), Protocol: model.HTTP}, Targets: targets, Matchers: matchers})
 		}
 
-		for i, route := range service.Spec.Tcp {
+		for _, route := range service.Spec.Tcp {
 
 			// Generate the targets
 			targets := make([]model.RouteTarget, len(route.Route))
@@ -344,7 +392,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 			}
 
 			// Set the route
-			routes[i] = &model.Route{ID: serviceID, Source: model.RouteSource{Port: int32(route.Match[0].Port), Protocol: model.TCP}, Targets: targets}
+			routes = append(routes, &model.Route{ID: serviceID, Source: model.RouteSource{Port: int32(route.Match[0].Port), Protocol: model.TCP}, Targets: targets})
 		}
 
 		// Set the routes of a service

--- a/runner/utils/driver/istio/get.go
+++ b/runner/utils/driver/istio/get.go
@@ -292,7 +292,7 @@ func (i *Istio) GetServiceRoutes(ctx context.Context, projectID string) (map[str
 					}
 					if regex := match.Uri.GetRegex(); regex != "" {
 						tempMatcher.URL.Type = model.RouteHTTPMatchTypeRegex
-						tempMatcher.URL.Value = match.Uri.GetRegex()
+						tempMatcher.URL.Value = regex
 					}
 				}
 

--- a/runner/utils/driver/istio/get_test.go
+++ b/runner/utils/driver/istio/get_test.go
@@ -245,9 +245,9 @@ func TestIstio_GetServiceRoutes(t *testing.T) {
 							},
 							{
 								URL: &model.HTTPMatcher{
-									Value:        "/v2/",
-									Type:         model.RouteHTTPMatchTypeExact,
-									IsIgnoreCase: true,
+									Value:      "/v2/",
+									Type:       model.RouteHTTPMatchTypeExact,
+									IgnoreCase: true,
 								},
 								Headers: []*model.HTTPMatcher{
 									{

--- a/runner/utils/driver/istio/get_test.go
+++ b/runner/utils/driver/istio/get_test.go
@@ -103,7 +103,7 @@ func TestIstio_GetServiceRoutes(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Get HTTP Routes with internal & external targets",
+			name: "Get HTTP Routes with internal, external targets & traffic splitting",
 			args: args{
 				ctx:       context.Background(),
 				projectID: "myProject",
@@ -123,8 +123,48 @@ func TestIstio_GetServiceRoutes(t *testing.T) {
 					Hosts: []string{getServiceDomainName("myProject", "greeter")},
 					Http: []*networkingv1alpha3.HTTPRoute{
 						{
-							Name:    fmt.Sprintf("http-%d", 8080),
-							Match:   []*networkingv1alpha3.HTTPMatchRequest{{Port: uint32(8080), Gateways: []string{"mesh"}}},
+							Name: fmt.Sprintf("http-%d", 8080),
+							Match: []*networkingv1alpha3.HTTPMatchRequest{
+								{
+									Uri: &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: "/v2/"}},
+									Headers: map[string]*networkingv1alpha3.StringMatch{
+										"version": {
+											MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: "v2"},
+										},
+									},
+									Port:     uint32(8080),
+									Gateways: []string{"mesh"},
+								},
+								{
+									Uri: &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Prefix{Prefix: "/v2/"}},
+									Headers: map[string]*networkingv1alpha3.StringMatch{
+										"version": {
+											MatchType: &networkingv1alpha3.StringMatch_Prefix{Prefix: "v2"},
+										},
+									},
+									Port:     uint32(8080),
+									Gateways: []string{"mesh"},
+								},
+								{
+									Uri: &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Regex{Regex: "/v2/"}},
+									Headers: map[string]*networkingv1alpha3.StringMatch{
+										"version": {
+											MatchType: &networkingv1alpha3.StringMatch_Regex{Regex: "v2"},
+										},
+									},
+									Port:     uint32(8080),
+									Gateways: []string{"mesh"},
+								},
+								{
+									Uri:           &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: "/v2/"}},
+									IgnoreUriCase: true,
+									Headers: map[string]*networkingv1alpha3.StringMatch{
+										"version": nil,
+									},
+									Port:     uint32(8080),
+									Gateways: []string{"mesh"},
+								},
+							},
 							Retries: &networkingv1alpha3.HTTPRetry{Attempts: 5, PerTryTimeout: &types.Duration{Seconds: model.DefaultRequestTimeout}},
 							Route: []*networkingv1alpha3.HTTPRouteDestination{
 								{
@@ -163,6 +203,60 @@ func TestIstio_GetServiceRoutes(t *testing.T) {
 						ID:             "greeter",
 						RequestRetries: 5,
 						RequestTimeout: model.DefaultRequestTimeout,
+						Matchers: []*model.Matcher{
+							{
+								URL: &model.HTTPMatcher{
+									Value: "/v2/",
+									Type:  model.RouteHTTPMatchTypeExact,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypeExact,
+									},
+								},
+							},
+							{
+								URL: &model.HTTPMatcher{
+									Value: "/v2/",
+									Type:  model.RouteHTTPMatchTypePrefix,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypePrefix,
+									},
+								},
+							},
+							{
+								URL: &model.HTTPMatcher{
+									Value: "/v2/",
+									Type:  model.RouteHTTPMatchTypeRegex,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypeRegex,
+									},
+								},
+							},
+							{
+								URL: &model.HTTPMatcher{
+									Value:        "/v2/",
+									Type:         model.RouteHTTPMatchTypeExact,
+									IsIgnoreCase: true,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:  "version",
+										Type: model.RouteHTTPMatchTypeCheckPresence,
+									},
+								},
+							},
+						},
 						Source: model.RouteSource{
 							Protocol: model.HTTP,
 							Port:     8080,

--- a/runner/utils/driver/istio/helpers.go
+++ b/runner/utils/driver/istio/helpers.go
@@ -258,7 +258,7 @@ func prepareVirtualServiceHTTPRoutes(ctx context.Context, projectID, serviceID s
 
 			// Add url matchers
 			if matcher.URL != nil {
-				tempMatcher.IgnoreUriCase = matcher.URL.IsIgnoreCase
+				tempMatcher.IgnoreUriCase = matcher.URL.IgnoreCase
 				tempMatcher.Uri = new(networkingv1alpha3.StringMatch)
 				switch matcher.URL.Type {
 				case model.RouteHTTPMatchTypeExact:

--- a/runner/utils/driver/istio/helpers.go
+++ b/runner/utils/driver/istio/helpers.go
@@ -252,10 +252,51 @@ func prepareVirtualServiceHTTPRoutes(ctx context.Context, projectID, serviceID s
 			}
 		}
 
+		matchers := make([]*networkingv1alpha3.HTTPMatchRequest, 0)
+		for _, matcher := range route.Matchers {
+			tempMatcher := new(networkingv1alpha3.HTTPMatchRequest)
+
+			// Add url matchers
+			if matcher.URL != nil {
+				tempMatcher.IgnoreUriCase = matcher.URL.IsIgnoreCase
+				tempMatcher.Uri = new(networkingv1alpha3.StringMatch)
+				switch matcher.URL.Type {
+				case model.RouteHTTPMatchTypeExact:
+					tempMatcher.Uri.MatchType = &networkingv1alpha3.StringMatch_Exact{Exact: matcher.URL.Value}
+				case model.RouteHTTPMatchTypePrefix:
+					tempMatcher.Uri.MatchType = &networkingv1alpha3.StringMatch_Prefix{Prefix: matcher.URL.Value}
+				case model.RouteHTTPMatchTypeRegex:
+					tempMatcher.Uri.MatchType = &networkingv1alpha3.StringMatch_Regex{Regex: matcher.URL.Value}
+				}
+			}
+
+			// 	Add header matchers
+			tempMatcher.Headers = map[string]*networkingv1alpha3.StringMatch{}
+			for _, header := range matcher.Headers {
+				switch header.Type {
+				case model.RouteHTTPMatchTypeExact:
+					tempMatcher.Headers[header.Key] = &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: header.Value}}
+				case model.RouteHTTPMatchTypePrefix:
+					tempMatcher.Headers[header.Key] = &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Prefix{Prefix: header.Value}}
+				case model.RouteHTTPMatchTypeRegex:
+					tempMatcher.Headers[header.Key] = &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Regex{Regex: header.Value}}
+				case model.RouteHTTPMatchTypeCheckPresence:
+					tempMatcher.Headers[header.Key] = &networkingv1alpha3.StringMatch{}
+				}
+			}
+
+			tempMatcher.Port = uint32(route.Source.Port)
+			tempMatcher.Gateways = []string{"mesh"}
+			matchers = append(matchers, tempMatcher)
+		}
+		if len(matchers) == 0 {
+			matchers = append(matchers, &networkingv1alpha3.HTTPMatchRequest{Port: uint32(route.Source.Port), Gateways: []string{"mesh"}})
+		}
+
 		// Add the http route
 		httpRoutes = append(httpRoutes, &networkingv1alpha3.HTTPRoute{
 			Name:    fmt.Sprintf("http-%d", route.Source.Port),
-			Match:   []*networkingv1alpha3.HTTPMatchRequest{{Port: uint32(route.Source.Port), Gateways: []string{"mesh"}}},
+			Match:   matchers,
 			Retries: &networkingv1alpha3.HTTPRetry{Attempts: route.RequestRetries, PerTryTimeout: &types.Duration{Seconds: route.RequestTimeout}},
 			Route:   destinations,
 		})

--- a/runner/utils/driver/istio/helpers_test.go
+++ b/runner/utils/driver/istio/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/gogo/protobuf/types"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 
 	"github.com/spaceuptech/space-cloud/runner/model"
@@ -354,6 +355,230 @@ func Test_prepareVirtualServiceTCPRoutes(t *testing.T) {
 			got, err := prepareVirtualServiceTCPRoutes(tt.args.ctx, tt.args.projectID, tt.args.serviceID, tt.args.services, tt.args.routes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("prepareVirtualServiceTCPRoutes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if arr := deep.Equal(got, tt.want); len(arr) > 0 {
+				a, _ := json.MarshalIndent(arr, "", " ")
+				t.Errorf("prepareVirtualServiceTCPRoutes() diff = %v", string(a))
+			}
+		})
+	}
+}
+
+func Test_prepareVirtualServiceHTTPRoutes(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		projectID string
+		serviceID string
+		services  map[string]model.AutoScaleConfig
+		routes    model.Routes
+		proxyPort uint32
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*networkingv1alpha3.HTTPRoute
+		wantErr bool
+	}{
+		{
+			name: "Multiple routes & multiple targets for TCP protocol",
+			args: args{
+				ctx:       context.Background(),
+				projectID: "myProject",
+				serviceID: "greeter",
+				services: map[string]model.AutoScaleConfig{
+					"v2": {
+						PollingInterval:  15,
+						CoolDownInterval: 120,
+						MinReplicas:      1,
+						MaxReplicas:      100,
+					},
+					"v3": {
+						PollingInterval:  15,
+						CoolDownInterval: 120,
+						MinReplicas:      1,
+						MaxReplicas:      100,
+					},
+				},
+				routes: []*model.Route{
+					{
+						ID: "greeter",
+						Source: model.RouteSource{
+							Protocol: model.HTTP,
+							Port:     8080,
+						},
+						Targets: []model.RouteTarget{
+							{
+								Port:    8080,
+								Weight:  25,
+								Version: "v2",
+								Type:    model.RouteTargetVersion,
+							},
+							{
+								Port:    8080,
+								Weight:  25,
+								Version: "v3",
+								Type:    model.RouteTargetVersion,
+							},
+							{
+								Port:   8080,
+								Weight: 25,
+								Type:   model.RouteTargetExternal,
+								Host:   "httpbin.test.svc.cluster.local",
+							},
+							{
+								Port:   8080,
+								Weight: 25,
+								Type:   model.RouteTargetExternal,
+								Host:   "httpbin.test.svc.cluster.local",
+							},
+						},
+						Matchers: []*model.Matcher{
+							{
+								URL: &model.HTTPMatcher{
+									Value:        "/v2/",
+									Type:         model.RouteHTTPMatchTypeExact,
+									IsIgnoreCase: true,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypeExact,
+									},
+								},
+							},
+							{
+								URL: &model.HTTPMatcher{
+									Value: "/v2/",
+									Type:  model.RouteHTTPMatchTypePrefix,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypePrefix,
+									},
+								},
+							},
+							{
+								URL: &model.HTTPMatcher{
+									Value: "/v2/",
+									Type:  model.RouteHTTPMatchTypeRegex,
+								},
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:   "version",
+										Value: "v2",
+										Type:  model.RouteHTTPMatchTypeRegex,
+									},
+								},
+							},
+							{
+								Headers: []*model.HTTPMatcher{
+									{
+										Key:  "version",
+										Type: model.RouteHTTPMatchTypeCheckPresence,
+									},
+								},
+							},
+						},
+					},
+				},
+				proxyPort: 4050,
+			},
+			want: []*networkingv1alpha3.HTTPRoute{
+				{
+					Name: "http-8080",
+					Match: []*networkingv1alpha3.HTTPMatchRequest{
+						{
+							Uri:           &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: "/v2/"}},
+							Headers:       map[string]*networkingv1alpha3.StringMatch{"version": {MatchType: &networkingv1alpha3.StringMatch_Exact{Exact: "v2"}}},
+							IgnoreUriCase: true,
+							Port:          uint32(8080),
+							Gateways:      []string{"mesh"},
+						},
+						{
+							Uri:      &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Prefix{Prefix: "/v2/"}},
+							Headers:  map[string]*networkingv1alpha3.StringMatch{"version": {MatchType: &networkingv1alpha3.StringMatch_Prefix{Prefix: "v2"}}},
+							Port:     uint32(8080),
+							Gateways: []string{"mesh"},
+						},
+						{
+							Uri:      &networkingv1alpha3.StringMatch{MatchType: &networkingv1alpha3.StringMatch_Regex{Regex: "/v2/"}},
+							Headers:  map[string]*networkingv1alpha3.StringMatch{"version": {MatchType: &networkingv1alpha3.StringMatch_Regex{Regex: "v2"}}},
+							Port:     uint32(8080),
+							Gateways: []string{"mesh"},
+						},
+						{
+							Headers:  map[string]*networkingv1alpha3.StringMatch{"version": {MatchType: nil}},
+							Port:     uint32(8080),
+							Gateways: []string{"mesh"},
+						},
+					},
+					Retries: &networkingv1alpha3.HTTPRetry{Attempts: 3, PerTryTimeout: &types.Duration{Seconds: 180}},
+					Route: []*networkingv1alpha3.HTTPRouteDestination{
+						{
+							Headers: &networkingv1alpha3.Headers{
+								Request: &networkingv1alpha3.Headers_HeaderOperations{
+									Set: map[string]string{
+										"x-og-project": "myProject",
+										"x-og-service": "greeter",
+										"x-og-host":    "greeter-v2-internal.myProject.svc.cluster.local",
+										"x-og-port":    "8080",
+										"x-og-version": "v2",
+									},
+								},
+							},
+							Destination: &networkingv1alpha3.Destination{
+								Host: getInternalServiceDomain("myProject", "greeter", "v2"),
+								Port: &networkingv1alpha3.PortSelector{Number: uint32(8080)},
+							},
+							Weight: 25,
+						},
+						{
+							Headers: &networkingv1alpha3.Headers{
+								Request: &networkingv1alpha3.Headers_HeaderOperations{
+									Set: map[string]string{
+										"x-og-project": "myProject",
+										"x-og-service": "greeter",
+										"x-og-host":    "greeter-v3-internal.myProject.svc.cluster.local",
+										"x-og-port":    "8080",
+										"x-og-version": "v3",
+									},
+								},
+							},
+							Destination: &networkingv1alpha3.Destination{
+								Host: getInternalServiceDomain("myProject", "greeter", "v3"),
+								Port: &networkingv1alpha3.PortSelector{Number: uint32(8080)},
+							},
+							Weight: 25,
+						},
+						{
+							Destination: &networkingv1alpha3.Destination{
+								Host: "httpbin.test.svc.cluster.local",
+								Port: &networkingv1alpha3.PortSelector{Number: uint32(8080)},
+							},
+							Weight: 25,
+						},
+						{
+							Destination: &networkingv1alpha3.Destination{
+								Host: "httpbin.test.svc.cluster.local",
+								Port: &networkingv1alpha3.PortSelector{Number: uint32(8080)},
+							},
+							Weight: 25,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := prepareVirtualServiceHTTPRoutes(tt.args.ctx, tt.args.projectID, tt.args.serviceID, tt.args.services, tt.args.routes, tt.args.proxyPort)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("prepareVirtualServiceHTTPRoutes() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if arr := deep.Equal(got, tt.want); len(arr) > 0 {

--- a/runner/utils/driver/istio/helpers_test.go
+++ b/runner/utils/driver/istio/helpers_test.go
@@ -436,9 +436,9 @@ func Test_prepareVirtualServiceHTTPRoutes(t *testing.T) {
 						Matchers: []*model.Matcher{
 							{
 								URL: &model.HTTPMatcher{
-									Value:        "/v2/",
-									Type:         model.RouteHTTPMatchTypeExact,
-									IsIgnoreCase: true,
+									Value:      "/v2/",
+									Type:       model.RouteHTTPMatchTypeExact,
+									IgnoreCase: true,
 								},
 								Headers: []*model.HTTPMatcher{
 									{

--- a/space-cli/cmd/modules/cluster/getters.go
+++ b/space-cli/cmd/modules/cluster/getters.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/spaceuptech/space-cloud/space-cli/cmd/model"
@@ -16,7 +15,7 @@ type resp struct {
 
 // GetClusterConfig gets clusters config
 func GetClusterConfig() ([]*model.SpecObject, error) {
-	url := fmt.Sprintf("/v1/config/cluster")
+	url := "/v1/config/cluster"
 
 	// Get the spec from the server
 	payload := new(resp)
@@ -40,7 +39,7 @@ func GetClusterConfig() ([]*model.SpecObject, error) {
 
 // GetIntegration gets integration
 func GetIntegration() ([]*model.SpecObject, error) {
-	url := fmt.Sprintf("/v1/config/integrations")
+	url := "/v1/config/integrations"
 
 	// Get the spec from the server
 	payload := new(model.Response)

--- a/space-cli/cmd/modules/services/generate.go
+++ b/space-cli/cmd/modules/services/generate.go
@@ -159,14 +159,147 @@ func GenerateServiceRoute(projectID string) (*model.SpecObject, error) {
 		return nil, err
 	}
 
-	var port int32
+	protocol := ""
+	if err := input.Survey.AskOne(&survey.Select{Message: "Select request protocol:", Options: []string{"http", "tcp"}}, &protocol); err != nil {
+		return nil, err
+	}
+
+	port := 0
 	if err := input.Survey.AskOne(&survey.Input{Message: "Enter Port:", Default: "8080"}, &port); err != nil {
 		return nil, err
 	}
 
-	version := ""
-	if err := input.Survey.AskOne(&survey.Input{Message: "Enter Version:"}, &version); err != nil {
+	retries := 0
+	if err := input.Survey.AskOne(&survey.Input{Message: "Enter Retries:", Default: "3"}, &retries); err != nil {
 		return nil, err
+	}
+
+	timeout := 0
+	if err := input.Survey.AskOne(&survey.Input{Message: "Enter Timeout in seconds:", Default: "180"}, &timeout); err != nil {
+		return nil, err
+	}
+
+	targets := make([]interface{}, 0)
+	totalWeight := 0
+	wantToAddAnotherTarget := false
+	for {
+
+		targetType := ""
+		if err := input.Survey.AskOne(&survey.Select{Message: "Select target type:", Options: []string{"version", "external"}}, &targetType); err != nil {
+			return nil, err
+		}
+
+		servicePort := 0
+		if err := input.Survey.AskOne(&survey.Input{Message: "Enter service port:"}, &servicePort); err != nil {
+			return nil, err
+		}
+
+		t := map[string]interface{}{"port": servicePort, "type": targetType}
+		if targetType == "external" {
+			address := ""
+			if err := input.Survey.AskOne(&survey.Input{Message: "Enter host address:"}, &address); err != nil {
+				return nil, err
+			}
+			t["host"] = address
+		} else {
+			version := ""
+			if err := input.Survey.AskOne(&survey.Input{Message: "Enter Version:"}, &version); err != nil {
+				return nil, err
+			}
+			t["version"] = version
+		}
+
+		weight := 0
+		if err := input.Survey.AskOne(&survey.Input{Message: "Enter weight"}, &weight); err != nil {
+			return nil, err
+		}
+		t["weight"] = weight
+
+		targets = append(targets, t)
+		totalWeight += weight
+		if totalWeight == 100 {
+			break
+		}
+		if err := input.Survey.AskOne(&survey.Confirm{Message: "Do you want to another target?"}, &wantToAddAnotherTarget); err != nil {
+			return nil, err
+		}
+		if !wantToAddAnotherTarget {
+			break
+		}
+	}
+
+	if totalWeight != 100 {
+		_ = utils.LogError("sum of weights of all targets should be 100", nil)
+		return nil, nil
+	}
+
+	matchers := make([]interface{}, 0)
+	wantToAddAnotherMatcher := false
+	for {
+
+		matcherType := ""
+		if err := input.Survey.AskOne(&survey.Select{Message: "Select matcher type:", Options: []string{"url", "header"}}, &matcherType); err != nil {
+			return nil, err
+		}
+
+		t := map[string]interface{}{}
+		if matcherType == "url" {
+			matchCondition := ""
+			if err := input.Survey.AskOne(&survey.Select{Message: "Select match condition:", Options: []string{"exact", "prefix", "regex"}}, &matchCondition); err != nil {
+				return nil, err
+			}
+
+			address := ""
+			if err := input.Survey.AskOne(&survey.Input{Message: "Enter URL:"}, &address); err != nil {
+				return nil, err
+			}
+
+			ignoreCase := false
+			if err := input.Survey.AskOne(&survey.Confirm{Message: "Do you want to ignore case?"}, &ignoreCase); err != nil {
+				return nil, err
+			}
+
+			t["url"] = map[string]interface{}{
+				"value":        address,
+				"type":         matchCondition,
+				"isIgnoreCase": ignoreCase,
+			}
+
+		} else {
+			matchCondition := ""
+			if err := input.Survey.AskOne(&survey.Select{Message: "Select match condition:", Options: []string{"exact", "prefix", "regex", "check-presence"}}, &matchCondition); err != nil {
+				return nil, err
+			}
+
+			headerKey := ""
+			if err := input.Survey.AskOne(&survey.Input{Message: "Enter header key:"}, &headerKey); err != nil {
+				return nil, err
+			}
+
+			headerValue := ""
+			if matchCondition != "check-presence" {
+				if err := input.Survey.AskOne(&survey.Input{Message: "Enter header value:"}, &headerValue); err != nil {
+					return nil, err
+				}
+			}
+
+			t["headers"] = []interface{}{
+				map[string]interface{}{
+					"key":   headerKey,
+					"value": headerValue,
+					"type":  matchCondition,
+				},
+			}
+		}
+
+		matchers = append(matchers, t)
+
+		if err := input.Survey.AskOne(&survey.Confirm{Message: "Do you want to add another matcher?"}, &wantToAddAnotherMatcher); err != nil {
+			return nil, err
+		}
+		if !wantToAddAnotherMatcher {
+			break
+		}
 	}
 
 	v := &model.SpecObject{
@@ -180,15 +313,13 @@ func GenerateServiceRoute(projectID string) (*model.SpecObject, error) {
 			"routes": []interface{}{
 				map[string]interface{}{
 					"source": map[string]interface{}{
-						"port": port,
+						"port":     port,
+						"protocol": protocol,
 					},
-					"targets": []interface{}{
-						map[string]interface{}{
-							"type":    "internal",
-							"version": version,
-							"weight":  100,
-						},
-					},
+					"requestRetries": retries,
+					"requestTimeout": timeout,
+					"matchers":       matchers,
+					"targets":        targets,
 				},
 			},
 		},


### PR DESCRIPTION
This fixes #1485 
1) Added support traffic splitting based on headers & URLs. Now you can specify matchers in service routes to split traffic conditionally.
2) Update service-routes resource of space cli generators to the latest structure.