### PR TITLE
Schema inspection fixes

### DIFF
--- a/gateway/modules/schema/template.go
+++ b/gateway/modules/schema/template.go
@@ -72,15 +72,17 @@ func generateSDL(schemaCol model.Collection) (string, error) {
 		"{{end}}" +
 
 		// @unique or @index directive
+		"{{ range $i, $sequence :=  (repeat 2) }}" + // for loop indexInfo
 		"{{range $k,$v := $fieldValue.IndexInfo }}" +
-		"{{if $v.IsUnique}}" +
-		"@unique(group: \"{{$v.Group}}\", order: {{$v.Order}}) " +
+		"{{if and (eq $sequence 1) $v.IsUnique}}" +
+		"@unique(group: \"{{$v.Group}}\", sort: \"{{$v.Sort}}\", order: {{$v.Order}}) " +
 		"{{else}}" +
-		"{{if $v.IsIndex}}" +
+		"{{if and (eq $sequence 2) $v.IsIndex}}" +
 		"@index(group: \"{{$v.Group}}\", sort: \"{{$v.Sort}}\", order: {{$v.Order}}) " +
 		"{{end}}" +
 		"{{end}}" +
 		"{{end}}" +
+		"{{end}}" + // for loop indexInfo
 
 		// @default directive
 		"{{if $fieldValue.IsDefault}}" +
@@ -119,7 +121,7 @@ func generateSDL(schemaCol model.Collection) (string, error) {
 		// Show primary keys first
 		"{{if and (eq $sequence 1) $fieldValue.IsPrimary}}" +
 		"{{template \"renderColumn\" $fieldValue}}" +
-		"{{else if and (eq $sequence 3) (gt (len $fieldValue.IndexInfo) 0) (not $fieldValue.IsForeign) }}" +
+		"{{else if and (eq $sequence 3) (gt (len $fieldValue.IndexInfo) 0) (not $fieldValue.IsForeign) (not $fieldValue.IsPrimary) (not $fieldValue.IsLinked) }}" +
 		"{{template \"renderColumn\" $fieldValue}}" +
 		"{{else if and (eq $sequence 4) $fieldValue.IsForeign}}" +
 		"{{template \"renderColumn\" $fieldValue}}" +

--- a/gateway/modules/schema/template_test.go
+++ b/gateway/modules/schema/template_test.go
@@ -108,7 +108,7 @@ func Test_generateSDL(t *testing.T) {
 						Kind:                model.TypeID,
 						TypeIDSize:          model.DefaultCharacterSize,
 						IndexInfo: []*model.TableProperties{{
-							IsIndex:  true,
+							IsIndex:  false,
 							IsUnique: true,
 							Group:    "user_name",
 							Order:    1,
@@ -157,7 +157,7 @@ func Test_generateSDL(t *testing.T) {
 				"\n\tspec: JSON" +
 				"\n\tupdatedAt: DateTime   @updatedAt" +
 				"\n\tfirst_name: ID!  @size(value: 100)    @index(group: \"user_name\", sort: \"asc\", order: 1)" +
-				"\n\tname: ID!  @size(value: 100)   @unique(group: \"user_name\", order: 1)" +
+				"\n\tname: ID!  @size(value: 100)   @unique(group: \"user_name\", sort: \"asc\",  order: 1)" +
 				"\n\tcustomer_id: ID!  @size(value: 100) @foreign(table: customer, field: id ,onDelete: cascade)" +
 				"\n\torder_dates: [DateTime]       @link(table: \"order\", from: \"id\", to: \"customer_id\", db:\"mongo\", field: \"order_date\")" +
 				"\n}",


### PR DESCRIPTION
1) Fixed schema inspection not returning sort value for unique indexes
2) From now onwards, schema inspection will generate index info in a fixed order. (first unique then index)
3) Fixed schema inspection generating multiple columns of the same field.