### PR TITLE
Added support changing the request payload format in graphQL API

### DIFF
--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -303,19 +303,24 @@ type Service struct {
 
 // Endpoint holds the config of a endpoint
 type Endpoint struct {
-	Kind      EndpointKind     `json:"kind" yaml:"kind" mapstructure:"kind"`
-	Tmpl      TemplatingEngine `json:"template,omitempty" yaml:"template,omitempty" mapstructure:"template"`
-	ReqTmpl   string           `json:"requestTemplate" yaml:"requestTemplate" mapstructure:"requestTemplate"`
-	GraphTmpl string           `json:"graphTemplate" yaml:"graphTemplate" mapstructure:"graphTemplate"`
-	ResTmpl   string           `json:"responseTemplate" yaml:"responseTemplate" mapstructure:"responseTemplate"`
-	OpFormat  string           `json:"outputFormat,omitempty" yaml:"outputFormat,omitempty" mapstructure:"outputFormat"`
-	Token     string           `json:"token,omitempty" yaml:"token,omitempty" mapstructure:"token"`
-	Claims    string           `json:"claims,omitempty" yaml:"claims,omitempty" mapstructure:"claims"`
-	Method    string           `json:"method" yaml:"method" mapstructure:"method"`
-	Path      string           `json:"path" yaml:"path" mapstructure:"path"`
-	Rule      *Rule            `json:"rule,omitempty" yaml:"rule,omitempty" mapstructure:"rule"`
-	Headers   Headers          `json:"headers,omitempty" yaml:"headers,omitempty" mapstructure:"headers"`
-	Timeout   int              `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout"` // Timeout is in seconds
+	Kind EndpointKind     `json:"kind" yaml:"kind" mapstructure:"kind"`
+	Tmpl TemplatingEngine `json:"template,omitempty" yaml:"template,omitempty" mapstructure:"template"`
+	// ReqPayloadFormat specifies the payload format
+	// depending upon the payload format, the graphQL request that
+	// gets converted to http request will use that format as it's payload
+	// currently supported formats are application/json,multipart/form-data
+	ReqPayloadFormat string  `json:"requestPayloadFormat" yaml:"requestPayloadFormat" mapstructure:"requestPayloadFormat"`
+	ReqTmpl          string  `json:"requestTemplate" yaml:"requestTemplate" mapstructure:"requestTemplate"`
+	GraphTmpl        string  `json:"graphTemplate" yaml:"graphTemplate" mapstructure:"graphTemplate"`
+	ResTmpl          string  `json:"responseTemplate" yaml:"responseTemplate" mapstructure:"responseTemplate"`
+	OpFormat         string  `json:"outputFormat,omitempty" yaml:"outputFormat,omitempty" mapstructure:"outputFormat"`
+	Token            string  `json:"token,omitempty" yaml:"token,omitempty" mapstructure:"token"`
+	Claims           string  `json:"claims,omitempty" yaml:"claims,omitempty" mapstructure:"claims"`
+	Method           string  `json:"method" yaml:"method" mapstructure:"method"`
+	Path             string  `json:"path" yaml:"path" mapstructure:"path"`
+	Rule             *Rule   `json:"rule,omitempty" yaml:"rule,omitempty" mapstructure:"rule"`
+	Headers          Headers `json:"headers,omitempty" yaml:"headers,omitempty" mapstructure:"headers"`
+	Timeout          int     `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout"` // Timeout is in seconds
 }
 
 // EndpointKind describes the type of endpoint. Default value - internal
@@ -330,6 +335,12 @@ const (
 
 	// EndpointKindPrepared describes an endpoint on on Space Cloud GraphQL layer
 	EndpointKindPrepared EndpointKind = "prepared"
+
+	// EndpointRequestPayloadFormatJSON specifies json payload format for the request
+	EndpointRequestPayloadFormatJSON string = "json"
+
+	// EndpointRequestPayloadFormatFormData specifies multipart/form-data payload format for the request
+	EndpointRequestPayloadFormatFormData string = "form-data"
 )
 
 // TemplatingEngine describes the type of endpoint. Default value - go

--- a/gateway/modules/functions/helpers.go
+++ b/gateway/modules/functions/helpers.go
@@ -187,7 +187,7 @@ func (m *Module) adjustReqBody(ctx context.Context, serviceID, endpointID, token
 			return nil, helpers.Logger.LogError(helpers.GetRequestID(ctx), fmt.Sprintf("Cannot marshal provided data for graphQL API endpoint (%s)", endpointID), err, map[string]interface{}{"serviceId": serviceID})
 		}
 		requestBody = bytes.NewReader(data)
-		endpoint.Headers = append(endpoint.Headers, config.Header{Key: "Content-Type", Value: "application/json", Op: "add"})
+		endpoint.Headers = append(endpoint.Headers, config.Header{Key: "Content-Type", Value: "application/json", Op: "set"})
 	case config.EndpointRequestPayloadFormatFormData:
 		buff := new(bytes.Buffer)
 		writer := multipart.NewWriter(buff)
@@ -204,7 +204,7 @@ func (m *Module) adjustReqBody(ctx context.Context, serviceID, endpointID, token
 			return nil, err
 		}
 		requestBody = bytes.NewReader(buff.Bytes())
-		endpoint.Headers = append(endpoint.Headers, config.Header{Key: "Content-Type", Value: writer.FormDataContentType(), Op: "add"})
+		endpoint.Headers = append(endpoint.Headers, config.Header{Key: "Content-Type", Value: writer.FormDataContentType(), Op: "set"})
 	}
 	return requestBody, err
 }

--- a/gateway/utils/http.go
+++ b/gateway/utils/http.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -16,7 +15,7 @@ type HTTPRequest struct {
 	Headers        headers
 	Method, URL    string
 	Token, SCToken string
-	Params         interface{}
+	Params         io.Reader
 }
 
 type headers interface {
@@ -25,17 +24,11 @@ type headers interface {
 
 // MakeHTTPRequest fires an http request and returns a response
 func MakeHTTPRequest(ctx context.Context, request *HTTPRequest, vPtr interface{}) (int, error) {
-	// Marshal json into byte array
-	data, _ := json.Marshal(request.Params)
-
 	// Make a request object
-	req, err := http.NewRequestWithContext(ctx, request.Method, request.URL, bytes.NewBuffer(data))
+	req, err := http.NewRequestWithContext(ctx, request.Method, request.URL, request.Params)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-
-	// Add the headers
-	req.Header.Add("Content-Type", "application/json")
 
 	// Add the token only if its provided
 	if request.Token != "" {


### PR DESCRIPTION
1) Added a config field in graphql API endpoints to specify the request payload format. Current it supports to formats json & form-data